### PR TITLE
memory implementation for bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT
 
-This is a [fork](https://gitlab.sabah.io/eol/mogunsamang) of a [fork](https://github.com/xmikos/hangupsbot).
+This is a fork of https://github.com/xmikos/hangupsbot
 
 * To execute: `python3 hangupsbot.py`
 * Any current tests will be in `<path of hangupsbot.py>/tests/`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ This procedure is necessary to let the bot know you're alive ;P
 No seriously, the above steps are **required** to authorise two-way
 communication between the bot and your own account.
 
+## Usage of @mentions
+
+Some general rules:
+* If `mentionquidproquo` is ON, only users who have already said something to 
+  the bot in private will be able to @mention others.
+* If a @mention matches multiple users, the bot will privately warn the user 
+  that too many users were selected. A list of all matching users will be 
+  provided as a guide to the user.
+* A @mention must be at least 3 characters or longer (not counting the `@`)
+
+A @mention matches the following:
+* A part of the combined first name and last name of the user 
+  e.g. `@abc` matches `AB Chin` (bot sees `abchin`)
+* A part of the combined first name and last name with spaces replaced by
+  the underscore
+  e.g. `@ab_c` matches `AB Chin` (bot sees `AB_Chin`)
+* An exact match with a user nickname, if the user has previously has
+  previously `/bot set nickname abc`
+  e.g. `@abc` matches nickname `abc` but NOT nicknames `abcd` or `zabc` 
+
 # Admins: Quick Installation & Configuration
 
 * `config.json` is found in two places:
@@ -227,8 +247,15 @@ configuration in `config.commands_admin`.
 * Bot will message user whether DND is toggled on or off.
 * User will not receive alerts for @mentions.
 
+`setnickname <nickname>`
+* Bot sets the nickname for the current user
+* `/whoami` will return the current nickname
+* Call it again to re-set the `<nickname>` as preferred
+
 `whoami`
-* Bot replies with the full name and `chat_id` of the current user.
+* Bot replies with the current user information:
+  * first name, nickname and `chat_id`, OR
+  * full name and `chat_id`
 
 `whereami`
 * Bot replies with the conversation name and `conversation id`.
@@ -240,12 +267,13 @@ configuration in `config.commands_admin`.
 * Adding optional second parameter `test` will show additional log information
   inside the current conversation when attempting to alert users. This
   can be used to check for any @mention errors with specific users.
-* Like @mentions, `<name fragment>` matches combined first name and last name.
 
 `lookup <keyword>`
 * Used in conjunction with a published Google Spreadsheet
-* Need to enable in config: `spreadsheet_enabled`, `spreadsheet_url` and `spreadsheet_table_class`
-* Will look up each row of a spreadsheet and if the keyword is found will return the whole row
+* Need to enable in config: `spreadsheet_enabled`, `spreadsheet_url` and 
+  `spreadsheet_table_class`
+* Will look up each row of a spreadsheet and if the keyword is found will 
+  return the whole row
 
 `prepare [<things>] <listdef>`
 * Bot prepares a list of `<things>` and puts them in a virtual box for lottery
@@ -259,6 +287,16 @@ configuration in `config.commands_admin`.
 * Each user must issue `/me draws` (or similar) to get a random item from the
   box. Note: `/me draw` always draws from "default" if available; to draw from
   another box, `/me draw [a|an] <thing>`
+
+# Developers: Debugging
+
+* Run the bot with the `-d` parameter e.g. `python3 hangupsbot.py -d` - this 
+  lowers the log level to `INFO` for a more verbose and informative log file.
+* `tail` the log file, which is probably located at
+  `/<user>/.local/share/hangupsbot/hangupsbot.log` - the location varies by 
+  distro!
+* Console output (STDOUT) is fairly limited whatever the log level, so rely
+  on the output of the log file instead.
 
 # Developers: Extending the Bot
 

--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -290,9 +290,9 @@ def mention(bot, event, *args):
     mention_chat_ids = []
 
     """check if synced room, if so, append on the users"""
-    if bot.get_config_option('sync_rooms'):
-        if event.conv_id in bot.get_config_option('sync_rooms'):
-            sync_room_list = bot.get_config_option('sync_rooms')
+    sync_room_list = bot.get_config_option('sync_rooms')
+    if sync_room_list:
+        if event.conv_id in sync_room_list:
             for syncedroom in sync_room_list:
                 if event.conv_id not in syncedroom:
                     users_in_chat += bot.get_users_in_conversation(syncedroom)

--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -615,13 +615,7 @@ def setnickname(bot, event, *args):
     truncatelength = 16 # What should the maximum length of the nickname be?
     nickname = ' '.join(args).strip()[0:truncatelength]
 
-    if not bot.memory.exists(["user_data"]):
-        # create the user_data grouping if it does not exist
-        bot.memory.set_by_path(["user_data"], {})
-
-    if not bot.memory.exists(["user_data", event.user.id_.chat_id]):
-        # create the user memory
-        bot.memory.set_by_path(["user_data", event.user.id_.chat_id], {})
+    bot.initialise_user_memory(event.user.id_.chat_id)
 
     bot.memory.set_by_path(["user_data", event.user.id_.chat_id, "nickname"], nickname)
     bot.memory.save()

--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -308,9 +308,8 @@ def mention(bot, event, *args):
     """
     quidproquo: users can only @mention if they themselves are @mentionable (i.e. have a 1-on-1 with the bot)
     """
-    conv_1on1_initiator = None
+    conv_1on1_initiator = bot.get_1on1_conversation(event.user.id_.chat_id)
     if bot.get_config_option("mentionquidproquo"):
-        conv_1on1_initiator = bot.get_1on1_conversation(event.user.id_.chat_id)
         if conv_1on1_initiator:
             logging.info("quidproquo: user {} ({}) has 1-on-1".format(event.user.full_name, event.user.id_.chat_id))
         else:

--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -7,6 +7,8 @@ from utils import text_to_segments
 
 from pushbullet import PushBullet
 
+from random import randint
+
 draw_lists = {}
 import re
 from random import shuffle
@@ -288,11 +290,12 @@ def mention(bot, event, *args):
     mention_chat_ids = []
 
     """check if synced room, if so, append on the users"""
-    if event.conv_id in bot.get_config_option('sync_rooms'):
-        sync_room_list = bot.get_config_option('sync_rooms')
-        for syncedroom in sync_room_list:
-            if event.conv_id not in syncedroom:
-                users_in_chat += bot.get_users_in_conversation(syncedroom)
+    if bot.get_config_option('sync_rooms'):
+        if event.conv_id in bot.get_config_option('sync_rooms'):
+            sync_room_list = bot.get_config_option('sync_rooms')
+            for syncedroom in sync_room_list:
+                if event.conv_id not in syncedroom:
+                    users_in_chat += bot.get_users_in_conversation(syncedroom)
 
     """
     /bot mention <fragment> test
@@ -622,6 +625,17 @@ def setnickname(bot, event, *args):
             "setting nickname to '{}'".format(nickname))
     bot.config.set_by_path(["nickname", event.user.id_.chat_id], { "ign": nickname })
     bot.config.save()
+
+@command.register
+def diceroll(bot, event, *args):
+    bot.send_message_parsed(event.conv, "<i>{} rolled <b>{}</b></i>".format(event.user.full_name, randint(1,6)))
+
+@command.register
+def coinflip(bot, event, *args):
+    if randint(1,2) == 1:
+        bot.send_message_parsed(event.conv, "<i>{}, coin turned up <b>heads</b></i>".format(event.user.full_name))
+    else:
+        bot.send_message_parsed(event.conv, "<i>{}, coin turned up <b>tails</b></i>".format(event.user.full_name))
 
 @command.register
 def prepare(bot, event, *args):

--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -427,9 +427,9 @@ def mention(bot, event, *args):
                 html += '<br />'
 
             bot.send_message_parsed(conv_1on1_initiator, html)
-            logging.info("@{} not sent due to multiple recipients".format(username_lower))
 
-            return #SHORT-CIRCUIT
+        logging.info("@{} not sent due to multiple recipients".format(username_lower))
+        return #SHORT-CIRCUIT
 
     """send @mention alerts"""
     for u in mention_list:

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -10,7 +10,7 @@
       "Hello world!"
     ]
   ],
-  "autoreplies_enabled": true,
+  "autoreplies_enabled": false,
   "commands_admin": [
     "rename",
     "leave",
@@ -79,9 +79,9 @@
       }
     }
   ],
-  "mentionerrors": true,
+  "mentionerrors": false,
   "mentionall":true,
   "mentionallwhitelist": [],
-  "mentionquidproquo": false,
+  "mentionquidproquo": true,
   "donotdisturb": []
 }

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -65,6 +65,17 @@ class Config(collections.MutableMapping):
             value = self.get_option(keyname)
         return value
 
+    def exists(self, keys_list):
+        _exists = True
+
+        try:
+            if self.get_by_path(keys_list) is None:
+                _exists = False
+        except (KeyError, TypeError):
+            _exists = False
+
+        return _exists
+
     def __getitem__(self, key):
         try:
             return self.config[key]

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -62,7 +62,7 @@ class Config(collections.MutableMapping):
         try:
             value = self.config[grouping][groupname][keyname]
         except KeyError:
-            value = self.get_config_option(keyname)
+            value = self.get_option(keyname)
         return value
 
     def __getitem__(self, key):

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -51,6 +51,20 @@ class Config(collections.MutableMapping):
         self.get_by_path(keys_list[:-1])[keys_list[-1]] = value
         self.changed = True
 
+    def get_option(self, keyname):
+        try:
+            value = self.config[keyname]
+        except KeyError:
+            value = None
+        return value
+
+    def get_suboption(self, grouping, groupname, keyname):
+        try:
+            value = self.config[grouping][groupname][keyname]
+        except KeyError:
+            value = self.get_config_option(keyname)
+        return value
+
     def __getitem__(self, key):
         try:
             return self.config[key]

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -27,6 +27,9 @@ class Config(collections.MutableMapping):
 
         self.changed = False
 
+    def force_taint(self):
+        self.changed = True
+
     def loads(self, json_str):
         """Load config from JSON string"""
         self.config = json.loads(json_str)

--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -5,7 +5,6 @@ import hangups
 import re, time
 
 from commands import command
-from random import randint
 
 from hangups.ui.utils import get_conv_name
 
@@ -221,12 +220,8 @@ class MessageHandler(object):
         """handle /me"""
         if event.text.startswith('/me'):
             if event.text.find("roll dice") > -1 or event.text.find("rolls dice") > -1 or event.text.find("rolls a dice") > -1 or event.text.find("rolled a dice") > -1:
-                self.bot.send_message_parsed(event.conv, "<i>{} rolled <b>{}</b></i>".format(event.user.full_name, randint(1,6)))
+                yield from command.run(self.bot, event, *["diceroll"])
             elif event.text.find("flips a coin") > -1 or event.text.find("flips coin") > -1 or event.text.find("flip coin") > -1 or event.text.find("flipped a coin") > -1:
-                if randint(1,2) == 1:
-                    self.bot.send_message_parsed(event.conv, "<i>{}, the coin turned up <b>heads</b></i>".format(event.user.full_name))
-                else:
-                    self.bot.send_message_parsed(event.conv, "<i>{}, the coin turned up <b>tails</b></i>".format(event.user.full_name))
-
+                yield from command.run(self.bot, event, *["coinflip"])
             else:
                 yield from command.run(self.bot, event, *["perform_drawing"])

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -233,35 +233,16 @@ class HangupsBot(object):
                 return c.users
 
     def get_config_option(self, option):
-        """Get config option"""
-        try:
-            option_value = self.config[option]
-        except KeyError:
-            option_value = None
-        return option_value
+        return self.config.get_option(option)
 
     def get_config_suboption(self, conv_id, option):
-        """Get config suboption for conversation (or global option if not defined)"""
-        try:
-            suboption = self.config['conversations'][conv_id][option]
-        except KeyError:
-            suboption = self.get_config_option(option)
-        return suboption
+        return self.config.get_suboption("conversations", conv_id, option)
 
     def get_memory_option(self, option):
-        try:
-            option_value = self.config[option]
-        except KeyError:
-            option_value = None
-        return option_value
+        return self.memory.get_option(option)
 
     def get_memory_suboption(self, user_id, option):
-        """Get memory suboption for user_data"""
-        try:
-            suboption = self.memory["user_data"][user_id][option]
-        except KeyError:
-            suboption = None
-        return suboption
+        return self.memory.get_option("user_data", user_id, option)
 
     def print_conversations(self):
         print('Conversations:')

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -222,7 +222,6 @@ class HangupsBot(object):
             logging.info("list_conversations() returned {} conversation(s)".format(len(convs)))
         except Exception as e:
             logging.warning("list_conversations()", e)
-            raise
 
         return convs
 

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -222,6 +222,7 @@ class HangupsBot(object):
             logging.info("list_conversations() returned {} conversation(s)".format(len(convs)))
         except Exception as e:
             logging.warning("list_conversations()", e)
+            raise
 
         return convs
 

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -242,7 +242,7 @@ class HangupsBot(object):
         return self.memory.get_option(option)
 
     def get_memory_suboption(self, user_id, option):
-        return self.memory.get_option("user_data", user_id, option)
+        return self.memory.get_suboption("user_data", user_id, option)
 
     def print_conversations(self):
         print('Conversations:')


### PR DESCRIPTION
* new utility functions for memory/config manipulation: `get_option`, `get_suboption`, exists
  * refactored `hangupsbot.py`:`get_config_option`, `get_config_suboption` to use new `config.py` utility functions
  * merged enhancement branch (d301ecd) + refactored: `get_memory_option`, `get_memory_suboption`
* implemented memory.json:
  * as a cache for remembering previous 1-to-1 conversations (a94f25e)
  * nicknames, label (first name + nickname)
  * call `hangupsbot.py`:`initialise_user_memory(chat_id)` before any check on stored values to ensure that the data store is properly initialised
* @mentions
  * added nickname support - must be exact match (ce7aab8)
  * allow usage of underscore for full name matches like "AB_Chin" (ce7aab8)
  * refactored user searching to deny multiple recipients if the @mention is too vague, initiating user will be warned by bot and shown all matched names (0a74330)
