### PR TITLE
autotranslate plugin for syncrooms

### DIFF
--- a/hangupsbot/plugins/simplytranslate.py
+++ b/hangupsbot/plugins/simplytranslate.py
@@ -15,8 +15,8 @@ def _handle_message(bot, event, command):
     for iso_language in language_map:
         text_language = language_map[iso_language].lower()
 
-        language_marker = "/" + text_language
-        if language_marker in raw_text:
+        language_marker = " /" + text_language
+        if raw_text.endswith(language_marker):
             raw_text = raw_text.replace(language_marker, "").strip()
             translate_target = [iso_language, text_language]
 

--- a/hangupsbot/plugins/simplytranslate.py
+++ b/hangupsbot/plugins/simplytranslate.py
@@ -1,0 +1,30 @@
+import goslate
+import asyncio
+
+gs = goslate.Goslate()
+
+def _initialise(command):
+    command.register_handler(_handle_message)
+
+@asyncio.coroutine
+def _handle_message(bot, event, command):
+    language_map = gs.get_languages()
+    raw_text = event.text.lower()
+    translate_target = None
+
+    for iso_language in language_map:
+        text_language = language_map[iso_language].lower()
+
+        language_marker = "/" + text_language
+        if language_marker in raw_text:
+            raw_text = raw_text.replace(language_marker, "").strip()
+            translate_target = [iso_language, text_language]
+
+    if translate_target is not None:
+        yield from _translate(bot, event, raw_text, translate_target[0], translate_target[1])
+
+@asyncio.coroutine
+def _translate(bot, event, text, iso_language, text_language):
+    print('TRANSLATE: "{}" to {}'.format(text, iso_language))
+    translated = gs.translate(text, iso_language)
+    bot.send_message_parsed(event.conv, "<i>" + text_language + "</i> : " + translated)

--- a/hangupsbot/plugins/syncrooms.py
+++ b/hangupsbot/plugins/syncrooms.py
@@ -158,6 +158,8 @@ def _handle_incoming_message(bot, event, command):
             for _conv_id in sync_room_list:
                 if not _conv_id == event.conv_id:
 
+                    _cloned_segments = list(segments)
+
                     _context = {}
                     _context["explicit_relay"] = True
 
@@ -166,7 +168,7 @@ def _handle_incoming_message(bot, event, command):
                             "conv_id" : event.conv_id,
                             "event_text" : event.text }
 
-                    bot.send_message_segments(_conv_id, segments, context=_context)
+                    bot.send_message_segments(_conv_id, _cloned_segments, context=_context)
 
             _registers.last_user_id = event.user_id.chat_id
             _registers.last_time_id = time.time()

--- a/hangupsbot/plugins/syncrooms.py
+++ b/hangupsbot/plugins/syncrooms.py
@@ -16,6 +16,7 @@ def _initialise(Handlers, bot=None):
     Handlers.register_handler(_handle_syncrooms_broadcast, type="sending")
     Handlers.register_handler(_handle_incoming_message, type="message")
     Handlers.register_handler(_handle_syncrooms_membership_change, type="membership")
+    return [] # implements no commands
 
 def _migrate_syncroom_v1(bot):
     if bot.config.exists(["conversations"]):

--- a/hangupsbot/plugins/syncrooms.py
+++ b/hangupsbot/plugins/syncrooms.py
@@ -1,6 +1,11 @@
 import asyncio, re, time
 
+import goslate
 import hangups
+
+from hangups.ui.utils import get_conv_name
+
+gs = goslate.Goslate()
 
 class __registers(object):
     def __init__(self):
@@ -16,7 +21,7 @@ def _initialise(Handlers, bot=None):
     Handlers.register_handler(_handle_syncrooms_broadcast, type="sending")
     Handlers.register_handler(_handle_incoming_message, type="message")
     Handlers.register_handler(_handle_syncrooms_membership_change, type="membership")
-    return [] # implements no commands
+    return ['synclanguage'] # implements no commands
 
 def _migrate_syncroom_v1(bot):
     if bot.config.exists(["conversations"]):
@@ -149,9 +154,22 @@ def _handle_incoming_message(bot, event, command):
                 if last != len(segment.text):
                     segments.append(hangups.ChatMessageSegment(segment.text[last:]))
 
+            origin_language = _get_syncroom_language(bot, event.conv_id)
+
             for _conv_id in sync_room_list:
                 if not _conv_id == event.conv_id:
-                    bot.send_message_segments(_conv_id, segments, context="no_syncrooms_handler")
+
+                    cloned_segments = list(segments) # we need this for multi-language
+
+                    target_language = _get_syncroom_language(bot, _conv_id)
+                    if origin_language != target_language:
+                        translated = gs.translate(event.text, target_language)
+                        if event.text != translated:
+                            cloned_segments.extend([
+                                hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
+                                hangups.ChatMessageSegment('(' + translated + ')')])
+
+                    bot.send_message_segments(_conv_id, cloned_segments, context="no_syncrooms_handler")
 
             _registers.last_user_id = event.user_id.chat_id
             _registers.last_time_id = time.time()
@@ -193,3 +211,33 @@ def _handle_syncrooms_membership_change(bot, event, command):
     else:
         print("SYNCROOMS: members left")
         bot.send_message(event.conv, '{} has left the Syncout'.format(names))
+
+
+def _get_syncroom_language(bot, conversation_id, default="en"):
+    syncroom_language = bot.conversation_memory_get(conversation_id, 'syncroom_language')
+    if syncroom_language is None:
+        return default
+    else:
+        return syncroom_language
+
+
+def synclanguage(bot, event, iso_language=None, *args):
+    language_map = gs.get_languages()
+
+    if iso_language is None:
+        bot.send_message_parsed(
+            event.conv,
+            '<i>syncroom "{}" language is {}</i>'.format(
+                get_conv_name(event.conv),
+                language_map[_get_syncroom_language(bot, event.conv_id)]))
+
+    if iso_language in language_map:
+        text_language = language_map[iso_language]
+
+        bot.conversation_memory_set(event.conv_id, 'syncroom_language', iso_language)
+
+        bot.send_message_parsed(
+            event.conv,
+            '<i>syncroom "{}" language set to {}</i>'.format(
+                get_conv_name(event.conv),
+                text_language))

--- a/hangupsbot/plugins/syncrooms.py
+++ b/hangupsbot/plugins/syncrooms.py
@@ -1,8 +1,6 @@
 import asyncio, re, time
 
-import goslate
 import hangups
-
 
 class __registers(object):
     def __init__(self):
@@ -13,13 +11,11 @@ class __registers(object):
 
 _registers=__registers()
 
-
 def _initialise(Handlers, bot=None):
     _migrate_syncroom_v1(bot)
     Handlers.register_handler(_handle_syncrooms_broadcast, type="sending")
     Handlers.register_handler(_handle_incoming_message, type="message")
     Handlers.register_handler(_handle_syncrooms_membership_change, type="membership")
-
 
 def _migrate_syncroom_v1(bot):
     if bot.config.exists(["conversations"]):
@@ -46,7 +42,6 @@ def _migrate_syncroom_v1(bot):
             bot.config.set_by_path(["sync_rooms"], _config2) # write new config
             bot.config.save()
             print("_migrate_syncroom_v1(): config-v2 = {}".format(_config2))
-
 
 def _handle_syncrooms_broadcast(bot, broadcast_list, context):
     """

--- a/hangupsbot/plugins/syncrooms_autotranslate.py
+++ b/hangupsbot/plugins/syncrooms_autotranslate.py
@@ -1,0 +1,58 @@
+import hangups
+import goslate
+
+from hangups.ui.utils import get_conv_name
+
+gs = goslate.Goslate()
+
+
+def _initialise(Handlers, bot=None):
+    Handlers.register_handler(_translate_message, type="sending")
+
+
+def _translate_message(bot, broadcast_list, context):
+    if context and "autotranslate" in context:
+        _autotranslate = context["autotranslate"]
+        origin_language = _get_syncroom_language(bot, _autotranslate["conv_id"])
+        for send in broadcast_list:
+            target_conversation_id = send[0]
+            response = send[1]
+            target_language = _get_syncroom_language(bot, target_conversation_id)
+            if origin_language != target_language:
+                print("AUTOTRANSLATE(): translating {} to {}".format(origin_language, target_language))
+                translated = gs.translate(_autotranslate["event_text"], target_language)
+                if _autotranslate["event_text"] != translated:
+                    # mutate the original response by reference
+                    response.extend([
+                        hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
+                        hangups.ChatMessageSegment('(' + translated + ')')])
+
+
+def _get_syncroom_language(bot, conversation_id, default="en"):
+    syncroom_language = bot.conversation_memory_get(conversation_id, 'syncroom_language')
+    if syncroom_language is None:
+        return default
+    else:
+        return syncroom_language
+
+
+def synclanguage(bot, event, iso_language=None, *args):
+    language_map = gs.get_languages()
+
+    if iso_language is None:
+        bot.send_message_parsed(
+            event.conv,
+            '<i>syncroom "{}" language is {}</i>'.format(
+                get_conv_name(event.conv),
+                language_map[_get_syncroom_language(bot, event.conv_id)]))
+
+    if iso_language in language_map:
+        text_language = language_map[iso_language]
+
+        bot.conversation_memory_set(event.conv_id, 'syncroom_language', iso_language)
+
+        bot.send_message_parsed(
+            event.conv,
+            '<i>syncroom "{}" language set to {}</i>'.format(
+                get_conv_name(event.conv),
+                text_language))

--- a/hangupsbot/plugins/syncrooms_autotranslate.py
+++ b/hangupsbot/plugins/syncrooms_autotranslate.py
@@ -8,16 +8,18 @@ gs = goslate.Goslate()
 
 def _initialise(Handlers, bot=None):
     Handlers.register_handler(_translate_message, type="sending")
+    return ['roomlanguage']
 
 
 def _translate_message(bot, broadcast_list, context):
     if context and "autotranslate" in context:
+        print(len(broadcast_list))
         _autotranslate = context["autotranslate"]
-        origin_language = _get_syncroom_language(bot, _autotranslate["conv_id"])
+        origin_language = _get_room_language(bot, _autotranslate["conv_id"])
         for send in broadcast_list:
             target_conversation_id = send[0]
             response = send[1]
-            target_language = _get_syncroom_language(bot, target_conversation_id)
+            target_language = _get_room_language(bot, target_conversation_id)
             if origin_language != target_language:
                 print("AUTOTRANSLATE(): translating {} to {}".format(origin_language, target_language))
                 translated = gs.translate(_autotranslate["event_text"], target_language)
@@ -28,7 +30,7 @@ def _translate_message(bot, broadcast_list, context):
                         hangups.ChatMessageSegment('(' + translated + ')')])
 
 
-def _get_syncroom_language(bot, conversation_id, default="en"):
+def _get_room_language(bot, conversation_id, default="en"):
     syncroom_language = bot.conversation_memory_get(conversation_id, 'syncroom_language')
     if syncroom_language is None:
         return default
@@ -36,23 +38,29 @@ def _get_syncroom_language(bot, conversation_id, default="en"):
         return syncroom_language
 
 
-def synclanguage(bot, event, iso_language=None, *args):
+def roomlanguage(bot, event, *args):
     language_map = gs.get_languages()
 
-    if iso_language is None:
-        bot.send_message_parsed(
-            event.conv,
-            '<i>syncroom "{}" language is {}</i>'.format(
-                get_conv_name(event.conv),
-                language_map[_get_syncroom_language(bot, event.conv_id)]))
+    language = " ".join(args)
 
-    if iso_language in language_map:
+    if not language:
+        try:
+            bot.send_message_parsed(
+                event.conv,
+                '<i>syncroom "{}" language is {}</i>'.format(
+                    get_conv_name(event.conv),
+                    language_map[_get_room_language(bot, event.conv_id)]))
+        except KeyError:
+            pass
+        return
+
+    for iso_language in language_map:
         text_language = language_map[iso_language]
-
-        bot.conversation_memory_set(event.conv_id, 'syncroom_language', iso_language)
-
-        bot.send_message_parsed(
-            event.conv,
-            '<i>syncroom "{}" language set to {}</i>'.format(
-                get_conv_name(event.conv),
-                text_language))
+        if language.lower() in text_language.lower() or language == iso_language.upper():
+            bot.conversation_memory_set(event.conv_id, 'syncroom_language', iso_language)
+            bot.send_message_parsed(
+                event.conv,
+                '<i>syncroom "{}" language set to {}</i>'.format(
+                    get_conv_name(event.conv),
+                    text_language))
+            break

--- a/hangupsbot/plugins/syncrooms_autotranslate.py
+++ b/hangupsbot/plugins/syncrooms_autotranslate.py
@@ -13,7 +13,6 @@ def _initialise(Handlers, bot=None):
 
 def _translate_message(bot, broadcast_list, context):
     if context and "autotranslate" in context:
-        print(len(broadcast_list))
         _autotranslate = context["autotranslate"]
         origin_language = _get_room_language(bot, _autotranslate["conv_id"])
         for send in broadcast_list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ asyncio
 jsonrpclib-pelix
 pushbullet.py
 beautifulsoup4
+goslate


### PR DESCRIPTION
* **syncrooms_autotranslate** - separate autotranslate plugin to allow automatic translation between syncrooms
* implements `/bot roomlanguage [<language>]`, specify optional parameter to set language (either 2-letter ALLCAPS ISO code or any-case language fragment e.g. "chinese (tra", "heBRE", etc. when called without parameters, shows the current room language setting
* merges **simplytranslate** plugin and makes it work only if the entire sentence **ends with** pattern `/<full language>`
* does not affect other plugins unless explicitly modified to allow autotranslation
* does not translate `/bot` and `/me` commands - hardcoded out of necessity