### PR TITLE
plugin framework v2.1

### DIFF
--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -56,9 +56,21 @@ command = CommandDispatcher()
 def help(bot, event, cmd=None, *args):
     """list supported commands"""
     if not cmd:
-        segments = [hangups.ChatMessageSegment('Supported commands:', is_bold=True),
+        admins_list = bot.get_config_suboption(event.conv_id, 'admins')
+
+        commands_all = command.commands.keys()
+        commands_admin = bot._handlers.get_admin_commands(event.conv_id)
+        commands_nonadmin = list(set(commands_all) - set(commands_admin))
+
+        segments = [hangups.ChatMessageSegment('User commands:', is_bold=True),
                     hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
-                    hangups.ChatMessageSegment(', '.join(sorted(command.commands.keys())))]
+                    hangups.ChatMessageSegment(', '.join(sorted(commands_nonadmin)))]
+
+        if event.user_id.chat_id in admins_list:
+            segments.extend([hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
+                             hangups.ChatMessageSegment('Admin commands:', is_bold=True),
+                             hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
+                             hangups.ChatMessageSegment(', '.join(sorted(commands_admin)))])
     else:
         try:
             command_fn = command.commands[cmd]

--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -62,21 +62,13 @@ def help(bot, event, cmd=None, *args):
         commands_admin = bot._handlers.get_admin_commands(event.conv_id)
         commands_nonadmin = list(set(commands_all) - set(commands_admin))
 
-        segments = [hangups.ChatMessageSegment('User commands:', is_bold=True),
-                    hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
-                    hangups.ChatMessageSegment(', '.join(sorted(commands_nonadmin)))]
-
+        text_html = '<b>User commands:</b><br />' + ', '.join(sorted(commands_nonadmin))
         if event.user_id.chat_id in admins_list:
-            segments.extend([hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
-                             hangups.ChatMessageSegment('Admin commands:', is_bold=True),
-                             hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
-                             hangups.ChatMessageSegment(', '.join(sorted(commands_admin)))])
+            text_html = text_html + '<br /><b>Admin commands:</b><br />' + ', '.join(sorted(commands_admin))
     else:
         try:
             command_fn = command.commands[cmd]
-            segments = [hangups.ChatMessageSegment('{}:'.format(cmd), is_bold=True),
-                        hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK)]
-            segments.extend(text_to_segments(command_fn.__doc__))
+            text_html = "<b>{}</b>: {}".format(cmd, command_fn.__doc__)
         except KeyError:
             yield from command.unknown_command(bot, event)
             return
@@ -84,11 +76,11 @@ def help(bot, event, cmd=None, *args):
     # help can get pretty long, so we send a short message publicly, and the actual help privately
     conv_1on1_initiator = bot.get_1on1_conversation(event.user.id_.chat_id)
     if conv_1on1_initiator:
-        bot.send_message_segments(conv_1on1_initiator, segments)
+        bot.send_message_parsed(conv_1on1_initiator, text_html)
         if conv_1on1_initiator.id_ != event.conv_id:
-            bot.send_message_parsed(event.conv, "{}, I've sent you some help ;)".format(event.user.full_name))
+            bot.send_message_parsed(event.conv, "<i>{}, I've sent you some help ;)</i>".format(event.user.full_name))
     else:
-        bot.send_message_parsed(event.conv, "{}, before I can help you, you need to private message me and say hi.".format(event.user.full_name))
+        bot.send_message_parsed(event.conv, "<i>{}, before I can help you, you need to private message me and say hi.</i>".format(event.user.full_name))
 
 
 @command.register

--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -15,9 +15,7 @@ class EventHandler(object):
         self.bot = bot
         self.bot_command = bot_command
 
-        self._current_plugin = {}
-
-        self.plugin_registered_admin_commands = []
+        self.explicit_admin_commands = [] # plugins can force some commands to be admin-only via register_admin_command()
 
         self.pluggables = { "message":[], "membership":[], "rename":[], "sending":[] }
 
@@ -55,7 +53,6 @@ class EventHandler(object):
             command_names = [command_names] # wrap into a list for consistent processing
         self._plugin_register_command("admin", command_names)
         self.plugin_registered_admin_commands.extend(command_names)
-
 
     def register_handler(self, function, type="message"):
         """call during plugin init to register a handler for a specific bot event"""

--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -15,17 +15,47 @@ class EventHandler(object):
         self.bot = bot
         self.bot_command = bot_command
 
+        self._current_plugin = {}
+
         self.plugin_registered_admin_commands = []
 
         self.pluggables = { "message":[], "membership":[], "rename":[], "sending":[] }
 
-    def register_admin_command(self, command_names):
-        """call during plugin init to make command(s) admin only"""
+    def plugin_preinit_stats(self):
+        """ 
+        hacky implementation for tracking commands a plugin registers
+        manually called by Hangupsbot._load_plugins() at start of each plugin load
+        """
+        self._current_plugin = {
+            "commands": {
+                "admin": [],
+                "user": []
+            }
+        }
+
+    def plugin_get_stats(self):
+        self._current_plugin["commands"]["all"] = list(set(self._current_plugin["commands"]["admin"] + 
+                                                           self._current_plugin["commands"]["user"]))
+        return self._current_plugin
+
+    def _plugin_register_command(self, type, command_names):
+        """call during plugin init to register commands"""
+        self._current_plugin["commands"][type].extend(command_names)
+        self._current_plugin["commands"][type] = list(set(self._current_plugin["commands"][type]))
+
+    def register_user_command(self, command_names):
+        """call during plugin init to register user commands"""
         if not isinstance(command_names, list):
             command_names = [command_names] # wrap into a list for consistent processing
-        for command in command_names:
-            # print('register_admin_command(): "{}" made admin-only'.format(command))
-            self.plugin_registered_admin_commands.append(command)
+        self._plugin_register_command("user", command_names)
+
+    def register_admin_command(self, command_names):
+        """call during plugin init to register admin commands"""
+        if not isinstance(command_names, list):
+            command_names = [command_names] # wrap into a list for consistent processing
+        self._plugin_register_command("admin", command_names)
+        self.plugin_registered_admin_commands.extend(command_names)
+
 
     def register_handler(self, function, type="message"):
         """call during plugin init to register a handler for a specific bot event"""

--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -52,7 +52,7 @@ class EventHandler(object):
         if not isinstance(command_names, list):
             command_names = [command_names] # wrap into a list for consistent processing
         self._plugin_register_command("admin", command_names)
-        self.plugin_registered_admin_commands.extend(command_names)
+        self.explicit_admin_commands.extend(command_names)
 
     def register_handler(self, function, type="message"):
         """call during plugin init to register a handler for a specific bot event"""
@@ -64,7 +64,7 @@ class EventHandler(object):
         commands_admin_list = self.bot.get_config_suboption(conversation_id, 'commands_admin')
         if not commands_admin_list:
             commands_admin_list = []
-        commands_admin_list = commands_admin_list + self.plugin_registered_admin_commands
+        commands_admin_list = commands_admin_list + self.explicit_admin_commands
         return commands_admin_list
 
     @asyncio.coroutine

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -311,7 +311,11 @@ class HangupsBot(object):
             """
             pass 1: run _initialise()/_initialize() and filter out "hidden" functions
 
-            legacy: _initialise()/_initialize() can optionally return a list of user-available functions
+            legacy notice: 
+            older plugins will return a list of user-available functions via _initialise/_initialize().
+            this LEGACY behaviour will continue to be supported. however, it is HIGHLY RECOMMENDED to
+            use register_user_command(<LIST command_names>) and register_admin_command(<LIST command_names>) 
+            for better security
             """
             available_commands = False # default: ALL
             try:
@@ -329,7 +333,6 @@ class HangupsBot(object):
                         pass
                     else:
                         candidate_commands.append((function_name, the_function))
-
                 if available_commands is False:
                     # implicit init, legacy support: assume all candidate_commands are user-available
                     self._handlers.register_user_command([function_name for function_name, function in candidate_commands])

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -304,50 +304,64 @@ class HangupsBot(object):
                 continue
 
             print("plugin: {}".format(module))
+            public_functions = [o for o in getmembers(sys.modules[module_path], isfunction)]
 
-            functions_list = [o for o in getmembers(sys.modules[module_path], isfunction)]
-
-            available_commands = False # default: ALL
             candidate_commands = []
 
             """
             pass 1: run _initialise()/_initialize() and filter out "hidden" functions
 
-            optionally, _initialise()/_initialize() can return a list of functions available to the user,
-                use this return value when importing functions from external libraries
-
+            legacy: _initialise()/_initialize() can optionally return a list of user-available functions
             """
+            available_commands = False # default: ALL
             try:
-                for function in functions_list:
-                    function_name = function[0]
+                self._handlers.plugin_preinit_stats()
+                for function_name, the_function in public_functions:
                     if function_name ==  "_initialise" or function_name ==  "_initialize":
                         try:
-                            _return = function[1](self._handlers, bot=self)
+                            _return = the_function(self._handlers, bot=self)
                         except TypeError as e:
                             # implement legacy support for plugins that don't support the bot reference
-                            _return = function[1](self._handlers)
+                            _return = the_function(self._handlers)
                         if type(_return) is list:
                             available_commands = _return
                     elif function_name.startswith("_"):
                         pass
                     else:
-                        candidate_commands.append(function)
+                        candidate_commands.append((function_name, the_function))
+
+                if available_commands is False:
+                    # implicit init, legacy support: assume all candidate_commands are user-available
+                    self._handlers.register_user_command([function_name for function_name, function in candidate_commands])
+                elif available_commands is []:
+                    # explicit init, no user-available commands
+                    pass
+                else:
+                    # explicit init, legacy support: _initialise() returned user-available commands
+                    self._handlers.register_user_command(available_commands)
             except Exception as e:
                 message = "{} @ {}".format(e, module_path)
                 print("EXCEPTION during plugin init: " + message)
                 logging.exception(message)
-                continue
+                continue # skip this, attempt next plugin
 
-            """pass 2: register filtered functions"""
-            added_commands = []
-            for function in candidate_commands:
-                function_name = function[0]
-                if available_commands is False or function_name in available_commands:
-                    command.register(function[1])
-                    added_commands.append(function_name)
+            """
+            pass 2: register filtered functions
+            """
+            plugin_tracking = self._handlers.plugin_get_stats()
+            explicit_admin_commands = plugin_tracking["commands"]["admin"]
+            all_commands = plugin_tracking["commands"]["all"]
+            registered_commands = []
+            for function_name, the_function in candidate_commands:
+                if function_name in all_commands:
+                    command.register(the_function)
+                    text_function_name = function_name
+                    if function_name in explicit_admin_commands:
+                        text_function_name = "*" + text_function_name
+                    registered_commands.append(text_function_name)
 
-            if added_commands:
-                print("  cmds: {}".format(", ".join(added_commands)))
+            if registered_commands:
+                print("added: {}".format(", ".join(registered_commands)))
 
 
     def _start_sinks(self, shared_loop):

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -299,11 +299,11 @@ class HangupsBot(object):
                 exec("import {}".format(module_path))
             except Exception as e:
                 message = "{} @ {}".format(e, module_path)
-                print("!PLUGIN IMPORT ERROR! " + message)
+                print("EXCEPTION during plugin import: " + message)
                 logging.exception(message)
                 continue
 
-            print("PLUGIN: {}".format(module))
+            print("plugin: {}".format(module))
 
             functions_list = [o for o in getmembers(sys.modules[module_path], isfunction)]
 
@@ -327,7 +327,6 @@ class HangupsBot(object):
                             # implement legacy support for plugins that don't support the bot reference
                             _return = function[1](self._handlers)
                         if type(_return) is list:
-                            print("implements: {}".format(", ".join(_return)))
                             available_commands = _return
                     elif function_name.startswith("_"):
                         pass
@@ -335,7 +334,7 @@ class HangupsBot(object):
                         candidate_commands.append(function)
             except Exception as e:
                 message = "{} @ {}".format(e, module_path)
-                print("!PLUGIN INIT ERROR! " + message)
+                print("EXCEPTION during plugin init: " + message)
                 logging.exception(message)
                 continue
 
@@ -346,7 +345,9 @@ class HangupsBot(object):
                 if available_commands is False or function_name in available_commands:
                     command.register(function[1])
                     added_commands.append(function_name)
-            print("added: {}".format(", ".join(added_commands)))
+
+            if added_commands:
+                print("  cmds: {}".format(", ".join(added_commands)))
 
 
     def _start_sinks(self, shared_loop):


### PR DESCRIPTION
* implements register_admin_command() and register_user_command() for more plugin control over which commands are available to user or admin
* updates `/bot help` to display user and admin-level commands + internal usage of html-based messages
* integrates with `config.commands_admin` and legacy return from `_initialise` for full backward compatibility with legacy plugins
* concise plugin init output - EXCEPTION always in CAPS, standard execution is lower-cased

