### PR TITLE
Merging Staging into Master: Mentions and DND fixes

### DIFF
--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -5,8 +5,14 @@ from hangups.ui.utils import get_conv_name
 
 from utils import text_to_segments
 
-def _initialise(command):
-    return ["users", "user", "hangouts", "rename", "leave", "reload", "quit", "config", "whoami", "whereami", "echo"]
+def _initialise(Handlers, bot=None):
+    if "register_admin_command" in dir(Handlers) and "register_user_command" in dir(Handlers):
+        Handlers.register_admin_command(["users", "user", "hangouts", "hangout", "rename", "leave", "reload", "quit", "config", "whereami"])
+        Handlers.register_user_command(["whoami", "echo"])
+        return []
+    else:
+        print("DEFAULT: LEGACY FRAMEWORK MODE")
+        return ["users", "user", "hangouts", "rename", "leave", "reload", "quit", "config", "whoami", "whereami", "echo", "hangout"]
 
 
 def echo(bot, event, *args):
@@ -85,6 +91,21 @@ def hangouts(bot, event, *args):
         line = line + "<br />"
 
     bot.send_message_parsed(event.conv, line)
+
+
+def hangout(bot, event, *args):
+    """list all hangouts matching search text"""
+    text_search = ' '.join(args)
+    if not text_search:
+        return
+    text_message = '<b>results for hangouts named "{}"</b><br />'.format(text_search)
+    for conv in bot.list_conversations():
+        conv_name = get_conv_name(conv)
+        if text_search.lower() in conv_name.lower():
+            text_message = text_message + "<i>" + conv_name + "</i>"
+            text_message = text_message + " ... " + conv.id_
+            text_message = text_message + "<br />"
+    bot.send_message_parsed(event.conv.id_, text_message)
 
 
 def rename(bot, event, *args):


### PR DESCRIPTION
* Toggling DND will stop the bot from notifying you about ANY mentions notifications whatsoever (including when you @mention more than one person in the same mention).
* Users who have never toggled DND on the bot before no longer have an error when attempting to noisy mention
* User will not be able to @mention people if their DND is toggled on.

This closes #87 