### PR TITLE
bugfix: user self-change nickname check

### DIFF
--- a/hangupsbot/plugins/mentions.py
+++ b/hangupsbot/plugins/mentions.py
@@ -396,9 +396,15 @@ def setnickname(bot, event, *args):
             if usernick:
                 nicks[userchatid] = usernick
 
-    # Now compare the new nickname with current nicks
+    # is the user trying to re-set his own nickname? - don't do anything if that is the case
+    if event.user.id_.chat_id in nicks:
+        if nickname == nicks[event.user.id_.chat_id]:
+            bot.send_message_parsed(event.conv, '<i>Your nickname is already "' + nickname + '".</i>')
+            return
+
+    # check whether another user has the same nickname
     if nickname in nicks.values():
-        bot.send_message_parsed(event.conv, "Error: Nickname already in use by somebody else!")
+        bot.send_message_parsed(event.conv, '<i>Nickname "' + nickname + '" is already in use by another user.</i>')
         return
 
     bot.initialise_memory(event.user.id_.chat_id, "user_data")


### PR DESCRIPTION
user will be informed appropriately if the nickname being changed is the same as his current nickname