### PR TITLE
added /bot optout to toggle suppression of all private messages from bot

### DIFF
--- a/hangupsbot/commands.py
+++ b/hangupsbot/commands.py
@@ -89,6 +89,25 @@ def ping(bot, event, *args):
     bot.send_message(event.conv, _('pong'))
 
 
+@command.register
+def optout(bot, event, *args):
+    """toggle opt-out of bot PM"""
+    optout = False
+    chat_id = event.user.id_.chat_id
+    bot.initialise_memory(chat_id, "user_data")
+    if bot.memory.exists(["user_data", chat_id, "optout"]):
+        optout = bot.memory.get_by_path(["user_data", chat_id, "optout"])
+    optout = not optout
+
+    bot.memory.set_by_path(["user_data", chat_id, "optout"], optout)
+    bot.memory.save()
+
+    if optout:
+        bot.send_message_parsed(event.conv, _('<i>{}, you <b>opted-out</b> from bot private messages</i>'.format(event.user.full_name)))
+    else:
+        bot.send_message_parsed(event.conv, _('<i>{}, you <b>opted-in</b> for bot private messages</i>'.format(event.user.full_name)))
+
+
 @command.register_unknown
 def unknown_command(bot, event, *args):
     """handle unknown commands"""

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -314,9 +314,13 @@ class HangupsBot(object):
         print()
 
     def get_1on1_conversation(self, chat_id):
-        conversation = None
-
         self.initialise_memory(chat_id, "user_data")
+
+        if self.memory.exists(["user_data", chat_id, "optout"]):
+            if self.memory.get_by_path(["user_data", chat_id, "optout"]):
+                return False
+
+        conversation = None
 
         if self.memory.exists(["user_data", chat_id, "1on1"]):
             conversation_id = self.memory.get_by_path(["user_data", chat_id, "1on1"])


### PR DESCRIPTION
allows users to `/bot opt-out` from bot private messages, this works by suppressing the return of the 1-to-1 conversation id to any requesting function. calling this command repeatedly will toggle optout on and off. note that some advanced administration commands require the usage of 1-to-1 conversations and thus these privileges will be denied to the user that has opt-out 