### PR TITLE
Workaround for FakeConversation OTR status

### DIFF
--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -226,6 +226,8 @@ class HangupsBot(object):
                 otr_status = (OffTheRecordStatus.OFF_THE_RECORD
                     if conversation.is_off_the_record
                     else OffTheRecordStatus.ON_THE_RECORD)
+            except KeyError:
+                pass
             except AttributeError:
                 pass
         elif isinstance(conversation, str):
@@ -235,6 +237,8 @@ class HangupsBot(object):
                 otr_status = (OffTheRecordStatus.OFF_THE_RECORD
                     if self._conv_list.get(conversation).is_off_the_record
                     else OffTheRecordStatus.ON_THE_RECORD)
+            except KeyError:
+                pass
             except AttributeError:
                 pass
         else:


### PR DESCRIPTION
If the conversation is new, it may yield a KeyError