### PR TITLE
Changed slack config port

### DIFF
--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -89,7 +89,7 @@
     {
     "certfile": null,
     "name": "SERVER_NAME",
-    "port": "LISTENING_PORT",
+    "port": 8085,
     "key": "SLACK_API_KEY",
     "channel": "#SLACK_CHANNEL_NAME",
     "synced_conversations": ["CONV_ID1", "CONV_ID2"]


### PR DESCRIPTION
The default port was a string, which we can't use with a socket. Changed it to an arbitrary number to prevent that issue from occurring, since new users may not realize that this needs to be a number. I spent a second trying to sort out why "8085" wasn't working before I realized string was no good.